### PR TITLE
Basic train loop and bug fixes

### DIFF
--- a/grpo.py
+++ b/grpo.py
@@ -107,13 +107,6 @@ def grpo_loss_fn(curr_model, old_model, ref_model, seq_ids, output_masks, reward
     # with grad for curr model -- for backprop
     curr_log_prob = get_model_log_prob(curr_model, seq_ids, output_masks, pad_token_id)   # (B,)
 
-    print(f"curr_log_prob: {curr_log_prob}")
-    print(f"curr_prob: {torch.exp(curr_log_prob)}")
-    print(f"old_log_prob: {old_log_prob}")
-    print(f"old_prob: {torch.exp(old_log_prob)}")
-    print(f"ref_log_prob: {ref_log_prob}")
-    print(f"ref_prob: {torch.exp(ref_log_prob)}")
-
     # policy objective
     adv = get_group_relative_reward_advantage(rewards)                     
     ratio = torch.exp(curr_log_prob - old_log_prob)

--- a/grpo.py
+++ b/grpo.py
@@ -102,17 +102,26 @@ def grpo_loss_fn(curr_model, old_model, ref_model, seq_ids, output_masks, reward
         ref_log_prob = get_model_log_prob(ref_model, seq_ids, output_masks)
 
     # with grad for curr model -- for backprop
-    curr_log_prob = get_model_log_prob(curr_model, seq_ids, output_masks)   # (B,) 
+    curr_log_prob = get_model_log_prob(curr_model, seq_ids, output_masks)   # (B,)
+    print(f"curr_log_prob: {curr_log_prob}")
+    print(f"curr_prob: {torch.exp(curr_log_prob)}")
+    print(f"old_log_prob: {old_log_prob}")
+    print(f"old_prob: {torch.exp(old_log_prob)}")
+    print(f"ref_log_prob: {ref_log_prob}")
+    print(f"ref_prob: {torch.exp(ref_log_prob)}")
 
     # policy objective
     adv = get_group_relative_reward_advantage(rewards)                     
-    ratio = torch.exp(curr_log_prob - old_log_prob)                        
+    ratio = torch.exp(curr_log_prob - old_log_prob)
+    print(f"ratio: {ratio}")
     unclipped = ratio * adv                                                
     clipped = torch.clamp(ratio, 1 - ep, 1 + ep) * adv                     
     policy_obj = torch.min(unclipped, clipped)                             
     # kl divergence
-    kl_div = get_kl_divergence(curr_log_prob, ref_log_prob)                
+    kl_div = get_kl_divergence(curr_log_prob, ref_log_prob)           
+    print(f"kl_div: {kl_div}")
     # grpo loss
     grpo_loss = policy_obj - (beta * kl_div)                                # (B,)
+    print(f"grpo_loss for batch: {grpo_loss}")
     grpo_loss = - grpo_loss.mean()                                          # (1,)
     return grpo_loss

--- a/nb/data_prep.ipynb
+++ b/nb/data_prep.ipynb
@@ -489,6 +489,113 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TEST"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/vijay/code/rft-grpo\n"
+     ]
+    }
+   ],
+   "source": [
+    "%cd .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from wordle import get_wordle_dataset\n",
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"google/gemma-3-1b-it\")\n",
+    "\n",
+    "dataset = get_wordle_dataset(tokenizer)\n",
+    "dataset = dataset.select(range(10))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_sample(sample):\n",
+    "    print_keys = [ 'secret', 'input']\n",
+    "    for key in print_keys:\n",
+    "        print(f\"{key.upper()}: \\n{sample[key]}\")\n",
+    "        print(\"-\"*30)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SECRET: \n",
+      "ALLOT\n",
+      "------------------------------\n",
+      "INPUT: \n",
+      "<bos><start_of_turn>user\n",
+      "You are playing Wordle, a word-guessing game.\n",
+      "\n",
+      "### Game Rules:\n",
+      "- You have **6 tries** to guess a secret **5-letter** word.\n",
+      "- Each guess must be a valid **5-letter English word**.\n",
+      "- After each guess, you will receive feedback indicating how close your guess was.\n",
+      "\n",
+      "### Feedback Format:\n",
+      "Each letter in your guess will receive one of three symbols:\n",
+      "1. ✓ : The letter is in the word and in the CORRECT position.\n",
+      "2. - : The letter is in the word but in the WRONG position.\n",
+      "3. x : The letter is NOT in the word.\n",
+      "\n",
+      "### Example:\n",
+      "Secret Word: BRISK\n",
+      "\n",
+      "Guess 1: STORM → Feedback: S(-) T(x) O(x) R(-) M(x)\n",
+      "Guess 2: BRAVE → Feedback: B(✓) R(✓) A(x) V(x) E(x)\n",
+      "Guess 3: BRISK → Feedback: B(✓) R(✓) I(✓) S(✓) K(✓)\n",
+      "\n",
+      "### Response Format:\n",
+      "Think through the problem and feedback step by step. Make sure to first add your step by step thought process within <think> </think> tags. Then, return your guessed word in the following format: <guess> guessed-word </guess>.\n",
+      "\n",
+      "Make a new 5-letter word guess.\n",
+      "\n",
+      " Here is some previous feedback:\n",
+      "Guess 1: CRANE -> Feedback: C(x) R(x) A(-) N(x) E(x)\n",
+      "Guess 2: ADULT -> Feedback: A(✓) D(x) U(x) L(-) T(✓)<end_of_turn>\n",
+      "<start_of_turn>model\n",
+      "Let me solve this step by step.\n",
+      "<think><end_of_turn>\n",
+      "<start_of_turn>model\n",
+      "\n",
+      "------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_sample(dataset[2])\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/nb/rft.ipynb
+++ b/nb/rft.ipynb
@@ -1854,27 +1854,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 260,
    "metadata": {},
    "outputs": [
@@ -1983,6 +1962,449 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "### Test training loop step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/vijay/code/rft-grpo\n"
+     ]
+    }
+   ],
+   "source": [
+    "%cd .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/vijay/code/rft-grpo/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using device: mps\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from rft import generate_batch, grpo_loss_fn, get_wordle_rewards\n",
+    "\n",
+    "def step(model, prev_model, ref_model, tokenizer, batch):\n",
+    "    \"\"\"\n",
+    "    Step learning rate scheduler\n",
+    "    \"\"\"\n",
+    "    device = model.device\n",
+    "    batch_input_ids, batch_output_masks, batch_output_texts = generate_batch(\n",
+    "        model=model,\n",
+    "        tokenizer=tokenizer,\n",
+    "        sample_inputs=batch['input'],\n",
+    "        num_generations=4,\n",
+    "        max_seq_len=128\n",
+    "    )\n",
+    "\n",
+    "    secret_word = batch['secret'][0]\n",
+    "    print(f\"SECRET: {batch['secret'][0]}\")\n",
+    "    for i, text in enumerate(batch_output_texts):\n",
+    "        print(f\"Generation {i}: {text}\")\n",
+    "\n",
+    "    batch_rewards = get_wordle_rewards(batch_output_texts, secret_word)\n",
+    "    print(f\"Batch rewards: {batch_rewards}\")\n",
+    "    batch_rewards = torch.tensor(batch_rewards, device=device)\n",
+    "\n",
+    "    # 3. GRPO - Calculate GRPO loss\n",
+    "    grpo_loss = grpo_loss_fn(\n",
+    "        curr_model=model,\n",
+    "        old_model=prev_model,\n",
+    "        ref_model=ref_model,\n",
+    "        seq_ids=batch_input_ids,\n",
+    "        output_masks=batch_output_masks,\n",
+    "        rewards=batch_rewards,\n",
+    "        pad_token_id=tokenizer.pad_token_id\n",
+    "    )\n",
+    "    print(f\"GRPO loss: {grpo_loss}\")\n",
+    "    # gradient clipping\n",
+    "    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)\n",
+    "    print(f\"Loss after gradient clipping: {grpo_loss}\")\n",
+    "\n",
+    "    return grpo_loss\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Base model dtype: torch.bfloat16\n",
+      "LoRA model dtype: torch.bfloat16\n",
+      "LoRA model info:\n",
+      "No. of trainable parameters: 745472\n",
+      "No. of non-trainable parameters: 999885952\n",
+      "Prev model dtype: torch.bfloat16\n",
+      "Prev model info:\n",
+      "No. of trainable parameters: 745472\n",
+      "No. of non-trainable parameters: 999885952\n"
+     ]
+    }
+   ],
+   "source": [
+    "# stup\n",
+    "from rft import load_base_model, load_lora_model, copy_peft_model_weights, print_model_info, get_wordle_dataset\n",
+    "\n",
+    "device = \"mps\"\n",
+    "model_name = \"google/gemma-3-1b-it\"\n",
+    "# print(f\"Loading model: {model_name}\")\n",
+    "# ref_model, tokenizer = load_base_model(model_name)\n",
+    "# print(f\"Ref model dtype: {ref_model.dtype}\")\n",
+    "# ref_model.requires_grad_(False)\n",
+    "# ref_model.to(device)\n",
+    "# print(\"Ref model info:\")\n",
+    "# print_model_info(ref_model)\n",
+    "\n",
+    "model, tokenizer = load_base_model(model_name)\n",
+    "print(f\"Base model dtype: {model.dtype}\")\n",
+    "model = load_lora_model(model)\n",
+    "print(f\"LoRA model dtype: {model.dtype}\")\n",
+    "model.to(device)\n",
+    "print(\"LoRA model info:\")\n",
+    "print_model_info(model)\n",
+    "\n",
+    "prev_model, _ = load_base_model(model_name)\n",
+    "prev_model = load_lora_model(prev_model)\n",
+    "prev_model = copy_peft_model_weights(model, prev_model)\n",
+    "prev_model.to(device)\n",
+    "print(f\"Prev model dtype: {prev_model.dtype}\")\n",
+    "# prev_model.requires_grad_(False)\n",
+    "print(\"Prev model info:\")\n",
+    "print_model_info(prev_model)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset loaded with 76 examples\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2. Load dataset - Wordle\n",
+    "dataset = get_wordle_dataset(tokenizer)\n",
+    "print(f\"Dataset loaded with {len(dataset)} examples\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SECRET: ALLOT\n",
+      "Generation 0: Okay, the first guess, CRANE, didn’t work well, revealing a lot of incorrect letters. Let’s try a different approach. I need to find a word with the correct letters and in the right positions. The letters I need are R, S, and K. I also need to include the letter T. Let’s start with a common word that contains these letters. Considering the feedback, I need to include 'T' and the letters 'R', 'S', 'K', and 'A'.\n",
+      "\n",
+      "My next guess is:  SLATER  → Feedback: S(-) L(-) T(✓)\n",
+      "Generation 1: Okay, let's analyze the feedback. The word is a 5-letter word, and I've already used one 'C' and one 'A'. This means I need to try words with 'R', 'S', 'B', 'I', 'E', and 'K'. The letters I've used are C, A, R, and B. I need to find a 5-letter word that doesn't contain these letters and has the remaining letters. I've seen 'S' appear in the feedback, so I'll try 'S'. Let’s see what happens.\n",
+      "\n",
+      "\n",
+      "Generation 2: Okay, let's analyze the feedback.\n",
+      "- Guess 1: CRANE – The letter ‘C’ is in the word, but it’s in the wrong position.\n",
+      "- Guess 2: ADULT – The letter ‘A’ is in the word, but it’s in the wrong position.\n",
+      "The letters ‘R’, ‘N’, ‘E’ are not in the word. We need to find a new word with the letters ‘C’, ‘A’, ‘D’, ‘U’, ‘L’ and ‘T’.\n",
+      "\n",
+      "Let's try a different approach. I'll keep track of the\n",
+      "Generation 3: Okay, let’s analyze the feedback. The word “CRANE” is not in the solution. The feedback indicates that C is in the word but in the wrong position. Let’s try a different word. I’ll start with a common 5-letter word. I’ll try to find a word with a common letter and a suitable position for the ‘C’.\n",
+      "\n",
+      "Let’s try “HEDGE”. The letter ‘H’ is in the word, but it’s in the wrong position.\n",
+      "<think>\n",
+      "Let’s try “SLATE”. The letter ‘S’ is in the word\n",
+      "Batch rewards: [0.0, 0.0, 0.0, 0.0]\n",
+      "curr_log_prob: tensor([-58.5686, -55.1530, -25.1425, -44.8060], device='mps:0',\n",
+      "       grad_fn=<SumBackward1>)\n",
+      "curr_prob: tensor([3.6641e-26, 1.1152e-24, 1.2043e-11, 3.4754e-20], device='mps:0',\n",
+      "       grad_fn=<ExpBackward0>)\n",
+      "old_log_prob: tensor([-58.2636, -55.9739, -24.7182, -44.7969], device='mps:0')\n",
+      "old_prob: tensor([4.9711e-26, 4.9073e-25, 1.8408e-11, 3.5070e-20], device='mps:0')\n",
+      "ref_log_prob: tensor([-56.7158, -54.6555, -24.5066, -44.3870], device='mps:0')\n",
+      "ref_prob: tensor([2.3369e-25, 1.8341e-24, 2.2748e-11, 5.2843e-20], device='mps:0')\n",
+      "ratio: tensor([0.7371, 2.2724, 0.6542, 0.9910], device='mps:0',\n",
+      "       grad_fn=<ExpBackward0>)\n",
+      "kl_div: tensor([3.5249, 0.1472, 0.2529, 0.1015], device='mps:0',\n",
+      "       grad_fn=<SubBackward0>)\n",
+      "grpo_loss for batch: tensor([-0.3525, -0.0147, -0.0253, -0.0101], device='mps:0',\n",
+      "       grad_fn=<SubBackward0>)\n",
+      "GRPO loss: 0.10066075623035431\n",
+      "Loss after gradient clipping: 0.10066075623035431\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "tensor(0.1007, device='mps:0', grad_fn=<NegBackward0>)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch = dataset.select([2])\n",
+    "step(\n",
+    "    model=model,\n",
+    "    prev_model=prev_model,\n",
+    "    ref_model=ref_model,\n",
+    "    tokenizer=tokenizer,\n",
+    "    batch=batch\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Debug > why curr and prev model probabilities are different during first step, even if the model weights are the same.!?\n",
+    "\n",
+    "Answer: This difference was due to `requires_grad_` difference between the current and prev policy models.\n",
+    "* curr model has `requires_grad_ = True` for LoRA layers.\n",
+    "* prev model has `requres_grad_ = False`\n",
+    "\n",
+    "Due to this difference, pytorch implements the computation kernels differently leading to different outputs.\n",
+    "* For inference only, computations are optimized optimized and operations might be fused.\n",
+    "* For training, computation graph is build and gradients are computed and tracked in different kernels.\n",
+    "\n",
+    "This behavior can be verified by setting same values for `requires_grad_` and then the outputs are exactly the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model parameters are the same\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "\n",
+    "def assert_model_same(model1, model2):\n",
+    "    for (name1, param1), (name2, param2) in zip(model1.named_parameters(), model2.named_parameters()):\n",
+    "        assert name1 == name2, f\"Model parameters are not the same: {name1} != {name2}\"\n",
+    "        assert param1.dtype == param2.dtype, f\"Model parameters are not the same for {name1}: {param1.dtype} != {param2.dtype}\"\n",
+    "        assert torch.allclose(param1.data, param2.data), f\"Model parameters are not the same for {name1}: {param1.data} != {param2.data}\"\n",
+    "    print(\"Model parameters are the same\")\n",
+    "\n",
+    "\n",
+    "assert_model_same(model, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model parameters are the same\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert_model_same(model, prev_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = get_wordle_dataset(tokenizer)\n",
+    "dataset = dataset.select(range(1))\n",
+    "samples = dataset.select([0])\n",
+    "\n",
+    "batch_input_ids, batch_output_masks, batch_output_texts = generate_batch(\n",
+    "                model=model, \n",
+    "                tokenizer=tokenizer, \n",
+    "                sample_inputs=samples['input'], \n",
+    "                num_generations=4, \n",
+    "                max_seq_len=128\n",
+    "            )\n",
+    "\n",
+    "secret_word = samples['secret'][0]\n",
+    "batch_rewards = get_wordle_rewards(batch_output_texts, secret_word)\n",
+    "batch_rewards = torch.tensor(batch_rewards, device=device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "False\n",
+      "No. of trainable parameters: 745472\n",
+      "No. of non-trainable parameters: 999885952\n",
+      "No. of trainable parameters: 0\n",
+      "No. of non-trainable parameters: 1000631424\n",
+      "Model parameters are the same\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.eval()\n",
+    "# model.requires_grad_(True)\n",
+    "prev_model.eval()\n",
+    "prev_model.requires_grad_(False)\n",
+    "print(model.training)\n",
+    "print(prev_model.training)\n",
+    "\n",
+    "print_model_info(model)\n",
+    "print_model_info(prev_model)\n",
+    "\n",
+    "assert_model_same(model, prev_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from grpo import get_model_log_prob\n",
+    "\n",
+    "curr_model_log_prob = get_model_log_prob(model, batch_input_ids, batch_output_masks, pad_token_id=tokenizer.pad_token_id)\n",
+    "prev_model_log_prob = get_model_log_prob(prev_model, batch_input_ids, batch_output_masks, pad_token_id=tokenizer.pad_token_id)\n",
+    "\n",
+    "curr_model_prob = torch.exp(curr_model_log_prob)\n",
+    "prev_model_prob = torch.exp(prev_model_log_prob)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mAssertionError\u001b[39m                            Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[16]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01massert\u001b[39;00m torch.equal(curr_model_log_prob, prev_model_log_prob)\n\u001b[32m      3\u001b[39m \u001b[38;5;28;01massert\u001b[39;00m torch.equal(curr_model_prob, prev_model_prob)\n",
+      "\u001b[31mAssertionError\u001b[39m: "
+     ]
+    }
+   ],
+   "source": [
+    "assert torch.equal(curr_model_log_prob, prev_model_log_prob)\n",
+    "\n",
+    "assert torch.equal(curr_model_prob, prev_model_prob)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([-46.3151, -27.8570, -32.3528, -49.7715], device='mps:0',\n",
+      "       grad_fn=<SumBackward1>)\n",
+      "tensor([-45.7787, -27.9371, -31.9956, -48.1270], device='mps:0')\n",
+      "tensor([7.6845e-21, 7.9773e-13, 8.8990e-15, 2.4240e-22], device='mps:0',\n",
+      "       grad_fn=<ExpBackward0>)\n",
+      "tensor([1.3139e-20, 7.3632e-13, 1.2720e-14, 1.2551e-21], device='mps:0')\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(curr_model_log_prob)\n",
+    "print(prev_model_log_prob)\n",
+    "\n",
+    "print(curr_model_prob)\n",
+    "print(prev_model_prob)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/rft.py
+++ b/rft.py
@@ -64,7 +64,7 @@ def train_rft():
 
         # shuffle
         dataset = dataset.shuffle(seed=epoch)
-        dataset = dataset.select(range(1))
+        dataset = dataset.select(range(5))
 
         for samples in dataset.iter(batch_size=num_samples):
             # 1. ACTION - Sample generations from current policy model

--- a/rft.py
+++ b/rft.py
@@ -55,7 +55,7 @@ def train_rft():
 
     # 4. Training loop
     # learning rate scheduler
-    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-6)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
     # lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=num_epochs, eta_min=1e-6)
 
     for epoch in range(num_epochs):

--- a/rft.py
+++ b/rft.py
@@ -40,7 +40,7 @@ def train_rft():
     # 2. Load dataset - Wordle
     # TODO - dataloader to shuffle and batch
     dataset = get_wordle_dataset(tokenizer)
-    dataset = dataset.select([3])
+    # dataset = dataset.select(range(10))
     print(f"Dataset loaded with {len(dataset)} examples")
 
     # 3. Training Parameters
@@ -86,7 +86,8 @@ def train_rft():
                 ref_model=ref_model, 
                 seq_ids=batch_input_ids, 
                 output_masks=batch_output_masks, 
-                rewards=batch_rewards
+                rewards=batch_rewards,
+                pad_token_id=tokenizer.pad_token_id
             )
             print(f"GRPO loss: {grpo_loss}")
             # gradient clipping

--- a/wordle.py
+++ b/wordle.py
@@ -3,11 +3,12 @@ Wordle dataset and reward function
 """
 
 import torch
+from datasets import Dataset
 
 
 ### DATASET ###
 
-def get_wordle_dataset(tokenizer, split="train"):
+def get_wordle_dataset(tokenizer, split="train") -> Dataset:
     """
     Load wordle dataset from path
     """


### PR DESCRIPTION
Updates:
- Set up basic train loop that runs on small sample without error
- Load dataset, setup models and run train.

Some bug fixes:
- Nan outputs in model log prob and loss calculation.
  - This was due to incorrectly setting `attention_mask` in `model.forward` method.
- Issue with copying of model weights using deepcopy. 
  - Fixed by copying weights layer by layer individually. 
- Difference in outputs between two copies of the same model.
  - Expected, due different values for `required_grad_` (True/False) between current and old policy models.
- Advantage calculation `division by zero` error
